### PR TITLE
feat: auto-reset db.json on EC2 from template & fix: use environment variables for API URLs in shared config and transactions service

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ A aplicação ByteBank está deployada em **arquitetura híbrida cloud**, combin
 
 🔒 **Segurança e Boas Práticas:** Ver [Práticas de Segurança em Cloud](./docs/SECURITY_PRACTICES.md) para detalhes sobre autenticação, autorização, proteção de rotas, configurações de segurança AWS/Vercel e checklist de conformidade.
 
+🔄 **Reset Automático do Banco de Dados:** O `db.json` é automaticamente resetado a cada deploy no EC2 (importante para novos módulos como investimentos).
+
 ## 🧱 Visão da Arquitetura
 
 - Shell App (porta 3030) — Host principal da aplicação

--- a/deploy-backend-ec2.sh
+++ b/deploy-backend-ec2.sh
@@ -9,6 +9,7 @@ echo ""
 
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+RED='\033[0;31m'
 NC='\033[0m'
 
 # 1. Parar containers front-end se estiverem rodando
@@ -21,12 +22,16 @@ echo -e "${BLUE}[2/5] Atualizando repositório...${NC}"
 cd ~/fiap-tech-challenge-2
 git pull
 
-# 3. Configurar banco de dados
-echo -e "${BLUE}[3/5] Configurando banco de dados...${NC}"
-if [ ! -f "db.json" ]; then
-    cp db.template.json db.json
-    echo -e "${GREEN}✓ db.json criado${NC}"
+# 3. Configurar banco de dados (template)
+echo -e "${BLUE}[3/5] Verificando template do banco de dados...${NC}"
+if [ ! -f "db.template.json" ]; then
+    echo -e "${RED}❌ Erro: db.template.json não encontrado!${NC}"
+    exit 1
 fi
+echo -e "${GREEN}✓ Template encontrado (db.json será resetado automaticamente no próximo start)${NC}"
+
+# 4. Tornar script de inicialização executável
+chmod +x docker/init-db.sh
 
 # 4. Criar pasta de uploads
 mkdir -p uploads

--- a/docker/docker-compose.backend.yml
+++ b/docker/docker-compose.backend.yml
@@ -8,11 +8,20 @@ services:
       - "3034:3034"
     volumes:
       - ../db.json:/data/db.json
+      - ../db.template.json:/data/db.template.json
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
     environment:
       - PORT=3034
     restart: unless-stopped
     networks:
       - bytebank-network
+    entrypoint: >
+      sh -c "
+        if [ -f /docker-entrypoint-initdb.d/init-db.sh ]; then
+          sh /docker-entrypoint-initdb.d/init-db.sh;
+        fi &&
+        exec json-server --watch /data/db.json --host 0.0.0.0 --port 3034
+      "
 
   upload:
     image: karenkramekfiap/bytebank-upload:latest

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script de inicialização do banco de dados
+# Este script é executado SEMPRE que o container sobe
+# Garante que o db.json seja resetado a partir do template
+
+set -e
+
+DB_FILE="/data/db.json"
+TEMPLATE_FILE="/data/db.template.json"
+
+echo "🔄 Inicializando banco de dados..."
+
+# Verifica se o template existe
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "❌ Erro: Template $TEMPLATE_FILE não encontrado!"
+    exit 1
+fi
+
+# SEMPRE sobrescreve o db.json com o template
+echo "📋 Resetando db.json a partir do template..."
+cp "$TEMPLATE_FILE" "$DB_FILE"
+
+echo "✅ Banco de dados resetado com sucesso!"
+echo "ℹ️  Base limpa iniciada a partir do template"

--- a/shared/src/config/app.config.ts
+++ b/shared/src/config/app.config.ts
@@ -1,8 +1,8 @@
 // Configurações do projeto
 export const AppConfig = {
   // URLs dos serviços
-  API_BASE_URL: 'http://localhost:3034',
-  UPLOAD_SERVICE_URL: 'http://localhost:3035',
+  API_BASE_URL: process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034',
+  UPLOAD_SERVICE_URL: process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035',
 
   // Configurações de upload
   MAX_FILE_SIZE: 5 * 1024 * 1024, // 5MB

--- a/transactions-mfe/src/services/api.ts
+++ b/transactions-mfe/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Account } from 'shared/models/Account';
 import { Transaction } from 'shared/models/Transaction';
 
-const API_BASE_URL = 'http://localhost:3034';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034';
 
 class TransactionAPIService {
   private api = axios.create({


### PR DESCRIPTION
# Fix: Adicionadas variáveis que estavam apontando para localhost

# Reset Automático do Banco de Dados

> **Resumo:** A partir de agora, o `db.json` no EC2 é **automaticamente resetado** a cada deploy. Isto é intencional e prepara o projeto para o módulo de investimentos.

---

## 🎯 O Que Mudou?

### ❌ **ANTES**
- Deploy no EC2 mantinha dados antigos no `db.json`
- Transações de teste se acumulavam
- Alterações no schema causavam erros

### ✅ **AGORA**
- **Cada deploy reseta o banco para o estado do `db.template.json`**
- Base sempre limpa e previsível
- Novos campos (como `investments`, quando for implementado) aplicados automaticamente


### ⚠️ **IMPORTANTE:** Seu ambiente local NÃO é afetado

- Dados locais continuam persistindo normalmente
- `docker compose -f docker/docker-compose.dev.yml` mantém dados entre reinícios
- Você tem controle total sobre quando resetar

### Se quiser resetar localmente (opcional):

```bash
# Opção 1: Script existente
./setup-db.sh

# Opção 2: Manual
cp db.template.json db.json

# Opção 3: Recriar volumes Docker
docker compose -f docker/docker-compose.dev.yml down -v
docker compose -f docker/docker-compose.dev.yml up
```
