### PR TITLE
fix: handle process.env safely to prevent browser errors

### DIFF
--- a/shared/src/config/app.config.ts
+++ b/shared/src/config/app.config.ts
@@ -1,8 +1,20 @@
+// Função helper para ler variáveis de ambiente de forma segura
+const getEnvVar = (key: string, defaultValue: string): string => {
+  try {
+    // @ts-ignore - process.env é injetado pelo Webpack
+    return typeof process !== 'undefined' && process.env && process.env[key]
+      ? process.env[key]
+      : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+};
+
 // Configurações do projeto
 export const AppConfig = {
   // URLs dos serviços
-  API_BASE_URL: process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034',
-  UPLOAD_SERVICE_URL: process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035',
+  API_BASE_URL: getEnvVar('REACT_APP_API_BASE_URL', 'http://localhost:3034'),
+  UPLOAD_SERVICE_URL: getEnvVar('REACT_APP_UPLOAD_URL', 'http://localhost:3035'),
 
   // Configurações de upload
   MAX_FILE_SIZE: 5 * 1024 * 1024, // 5MB

--- a/shared/webpack.config.js
+++ b/shared/webpack.config.js
@@ -103,7 +103,8 @@ module.exports = {
       }
     }),
     new webpack.DefinePlugin({
-      'process.env.REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034')
+      'process.env.REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034'),
+      'process.env.REACT_APP_UPLOAD_URL': JSON.stringify(process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035')
     })
   ],
   entry: './src/app/index.ts',

--- a/transactions-mfe/src/services/api.ts
+++ b/transactions-mfe/src/services/api.ts
@@ -2,7 +2,19 @@ import axios from 'axios';
 import { Account } from 'shared/models/Account';
 import { Transaction } from 'shared/models/Transaction';
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034';
+// Função helper para ler variáveis de ambiente de forma segura
+const getEnvVar = (key: string, defaultValue: string): string => {
+  try {
+    // @ts-ignore - process.env é injetado pelo Webpack
+    return typeof process !== 'undefined' && process.env && process.env[key]
+      ? process.env[key]
+      : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+};
+
+const API_BASE_URL = getEnvVar('REACT_APP_API_BASE_URL', 'http://localhost:3034');
 
 class TransactionAPIService {
   private api = axios.create({


### PR DESCRIPTION
- Add getEnvVar helper function to safely read environment variables
- Prevent 'process is not defined' ReferenceError in browser
- Add REACT_APP_UPLOAD_URL to Webpack DefinePlugin in shared
- Ensure fallback to localhost for local development

Fixes white screen issue caused by accessing process.env directly in browser context without Webpack injection.