### PR TITLE
fix: update all webpack configs to use global constants

### DIFF
--- a/dashboard-mfe/webpack.config.js
+++ b/dashboard-mfe/webpack.config.js
@@ -56,8 +56,8 @@ module.exports = {
   },
   plugins: [
     new DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
-      'process.env.REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034')
+      'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+      'REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034')
     }),
     new ModuleFederationPlugin({
       name: 'dashboardMFE',

--- a/shared/src/config/app.config.ts
+++ b/shared/src/config/app.config.ts
@@ -1,20 +1,12 @@
-// Função helper para ler variáveis de ambiente de forma segura
-const getEnvVar = (key: string, defaultValue: string): string => {
-  try {
-    // @ts-ignore - process.env é injetado pelo Webpack
-    return typeof process !== 'undefined' && process.env && process.env[key]
-      ? process.env[key]
-      : defaultValue;
-  } catch {
-    return defaultValue;
-  }
-};
+// Declaração global para TypeScript reconhecer as variáveis injetadas pelo Webpack
+declare const REACT_APP_API_BASE_URL: string | undefined;
+declare const REACT_APP_UPLOAD_URL: string | undefined;
 
 // Configurações do projeto
 export const AppConfig = {
   // URLs dos serviços
-  API_BASE_URL: getEnvVar('REACT_APP_API_BASE_URL', 'http://localhost:3034'),
-  UPLOAD_SERVICE_URL: getEnvVar('REACT_APP_UPLOAD_URL', 'http://localhost:3035'),
+  API_BASE_URL: typeof REACT_APP_API_BASE_URL !== 'undefined' ? REACT_APP_API_BASE_URL : 'http://localhost:3034',
+  UPLOAD_SERVICE_URL: typeof REACT_APP_UPLOAD_URL !== 'undefined' ? REACT_APP_UPLOAD_URL : 'http://localhost:3035',
 
   // Configurações de upload
   MAX_FILE_SIZE: 5 * 1024 * 1024, // 5MB

--- a/shared/webpack.config.js
+++ b/shared/webpack.config.js
@@ -103,8 +103,8 @@ module.exports = {
       }
     }),
     new webpack.DefinePlugin({
-      'process.env.REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034'),
-      'process.env.REACT_APP_UPLOAD_URL': JSON.stringify(process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035')
+      'REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034'),
+      'REACT_APP_UPLOAD_URL': JSON.stringify(process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035')
     })
   ],
   entry: './src/app/index.ts',

--- a/shell/webpack.config.js
+++ b/shell/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const { DefinePlugin } = require("webpack");
 
 module.exports = {
   entry: "./src/app/index.tsx",
@@ -49,6 +50,11 @@ module.exports = {
     ],
   },
   plugins: [
+    new DefinePlugin({
+      'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+      'REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034'),
+      'REACT_APP_UPLOAD_URL': JSON.stringify(process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035')
+    }),
     new ModuleFederationPlugin({
       name: "shell",
       remotes: {

--- a/transactions-mfe/src/services/api.ts
+++ b/transactions-mfe/src/services/api.ts
@@ -2,19 +2,10 @@ import axios from 'axios';
 import { Account } from 'shared/models/Account';
 import { Transaction } from 'shared/models/Transaction';
 
-// Função helper para ler variáveis de ambiente de forma segura
-const getEnvVar = (key: string, defaultValue: string): string => {
-  try {
-    // @ts-ignore - process.env é injetado pelo Webpack
-    return typeof process !== 'undefined' && process.env && process.env[key]
-      ? process.env[key]
-      : defaultValue;
-  } catch {
-    return defaultValue;
-  }
-};
+// Declaração global para TypeScript reconhecer a variável injetada pelo Webpack
+declare const REACT_APP_API_BASE_URL: string | undefined;
 
-const API_BASE_URL = getEnvVar('REACT_APP_API_BASE_URL', 'http://localhost:3034');
+const API_BASE_URL = typeof REACT_APP_API_BASE_URL !== 'undefined' ? REACT_APP_API_BASE_URL : 'http://localhost:3034';
 
 class TransactionAPIService {
   private api = axios.create({

--- a/transactions-mfe/webpack.config.js
+++ b/transactions-mfe/webpack.config.js
@@ -56,8 +56,9 @@ module.exports = {
   },
   plugins: [
     new DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
-      'process.env.REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034')
+      'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+      'REACT_APP_API_BASE_URL': JSON.stringify(process.env.REACT_APP_API_BASE_URL || 'http://localhost:3034'),
+      'REACT_APP_UPLOAD_URL': JSON.stringify(process.env.REACT_APP_UPLOAD_URL || 'http://localhost:3035')
     }),
     new ModuleFederationPlugin({
       name: 'transactionsMFE',


### PR DESCRIPTION
- Update shared/webpack.config.js: use global constants
- Update dashboard-mfe/webpack.config.js: use global constants
- Update transactions-mfe/webpack.config.js: add UPLOAD_URL, use global constants
- Update shell/webpack.config.js: add DefinePlugin with all env vars
- Update app.config.ts: use global constants instead of process.env
- Update api.ts: use global constants instead of process.env

All projects now inject variables as global constants at build time, completely eliminating 'process is not defined' browser errors.

This fixes the white screen issue by ensuring all MFEs have consistent environment variable handling across Shell, Dashboard, Transactions, and Shared.