### PR TITLE
feat: add Content-Security-Policy to upgrade insecure requests

### DIFF
--- a/dashboard-mfe/vercel.json
+++ b/dashboard-mfe/vercel.json
@@ -12,6 +12,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/remoteEntry.js",
       "headers": [
         {

--- a/shared/vercel.json
+++ b/shared/vercel.json
@@ -12,6 +12,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/remoteEntry.js",
       "headers": [
         {

--- a/shell/vercel.json
+++ b/shell/vercel.json
@@ -12,6 +12,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/remoteEntry.js",
       "headers": [
         {

--- a/transactions-mfe/vercel.json
+++ b/transactions-mfe/vercel.json
@@ -12,6 +12,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/remoteEntry.js",
       "headers": [
         {


### PR DESCRIPTION
- Add 'upgrade-insecure-requests' CSP header to all vercel.json files
- Instructs browser to automatically upgrade HTTP requests to HTTPS
- Fixes mixed content blocking without needing proxy or env var changes
- Simpler solution than rewriting API URLs

This allows HTTPS Vercel frontends to make requests to HTTP EC2 backend by having the browser automatically upgrade the connection when possible.

No environment variable changes needed - keeps existing URLs:
- REACT_APP_API_BASE_URL=http://44.206.72.128:3034
- REACT_APP_UPLOAD_URL=http://44.206.72.128:3035