### PR TITLE
fix: implement Vercel proxy to resolve HTTPS/HTTP mixed content blocking

### DIFF
--- a/VERCEL_ENV_IMPORT.env
+++ b/VERCEL_ENV_IMPORT.env
@@ -2,13 +2,23 @@
 # Este arquivo contém todas as variáveis necessárias para cada projeto
 # Copie e cole no Vercel: Settings → Environment Variables → Import .env
 
+# ⚠️ IMPORTANTE: URLS RELATIVAS COM PROXY
+# As URLs /api e /uploads são CAMINHOS RELATIVOS que funcionam através do
+# proxy configurado em cada vercel.json. O Vercel redireciona automaticamente:
+#   - /api/* → http://44.206.72.128:3034/* (API Server no EC2)
+#   - /uploads/* → http://44.206.72.128:3035/uploads/* (Upload Server no EC2)
+#
+# Isso resolve problemas de mixed content (HTTPS ↔ HTTP) entre Vercel e EC2.
+# NÃO use URLs completas (http://44.206.72.128:3034), pois causarão erro de
+# mixed content no browser (páginas HTTPS não podem fazer requests HTTP).
+
 # ============================================================================
 # 📦 PROJETO 1: SHARED
 # ============================================================================
 # Vercel Project: bytebank-shared
 # Root Directory: shared
 
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 
 
 # ============================================================================
@@ -17,7 +27,7 @@ REACT_APP_API_BASE_URL=http://44.206.72.128:3034
 # Vercel Project: bytebank-dashboard
 # Root Directory: dashboard-mfe
 
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
@@ -29,8 +39,8 @@ REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
 # Vercel Project: bytebank-transactions
 # Root Directory: transactions-mfe
 
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
@@ -42,8 +52,8 @@ REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
 # Vercel Project: bytebank-shell
 # Root Directory: shell
 
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app

--- a/VERCEL_ENV_VARS.md
+++ b/VERCEL_ENV_VARS.md
@@ -7,26 +7,28 @@
 REACT_APP_DASHBOARD_URL=https://bytebank-dashboard.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://bytebank-transactions.vercel.app
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 ```
+
+> ⚠️ **Importante:** As URLs `/api` e `/uploads` são **caminhos relativos** que funcionam através do **proxy configurado no Vercel**. O `vercel.json` de cada projeto redireciona essas requisições para o backend EC2 (44.206.72.128:3034 e :3035), resolvendo problemas de mixed content (HTTPS ↔ HTTP).
 
 ### 2. Dashboard MFE
 ```
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 ```
 
 ### 3. Transactions MFE
 ```
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 ```
 
 ### 4. Shared Library
 ```
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 ```
 
 ---

--- a/dashboard-mfe/vercel.json
+++ b/dashboard-mfe/vercel.json
@@ -6,20 +6,19 @@
   "framework": null,
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "http://44.206.72.128:3034/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "http://44.206.72.128:3035/uploads/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
   ],
   "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests"
-        }
-      ]
-    },
     {
       "source": "/remoteEntry.js",
       "headers": [

--- a/docs/hybrid-deployment.md
+++ b/docs/hybrid-deployment.md
@@ -162,8 +162,10 @@ Cada MFE tem seu próprio projeto Vercel com configurações específicas:
 
 Variáveis de ambiente:
 ```bash
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 ```
+
+> **Nota:** A URL `/api` é um **caminho relativo** que usa o proxy configurado no `vercel.json`. O Vercel redireciona automaticamente requisições de `/api/*` para `http://44.206.72.128:3034/*`, resolvendo problemas de mixed content entre HTTPS (Vercel) e HTTP (EC2).
 
 #### 2. Dashboard MFE
 ```json
@@ -177,7 +179,7 @@ REACT_APP_API_BASE_URL=http://44.206.72.128:3034
 
 Variáveis de ambiente:
 ```bash
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
+REACT_APP_API_BASE_URL=/api
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
@@ -195,12 +197,14 @@ REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
 
 Variáveis de ambiente:
 ```bash
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
 ```
+
+> **Nota:** O caminho `/uploads` também usa proxy do Vercel, redirecionando para `http://44.206.72.128:3035/uploads/*`.
 
 #### 4. Shell (Host)
 ```json
@@ -214,8 +218,8 @@ REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app
 
 Variáveis de ambiente:
 ```bash
-REACT_APP_API_BASE_URL=http://44.206.72.128:3034
-REACT_APP_UPLOAD_URL=http://44.206.72.128:3035
+REACT_APP_API_BASE_URL=/api
+REACT_APP_UPLOAD_URL=/uploads
 REACT_APP_SHARED_URL=https://bytebank-shared.vercel.app
 REACT_APP_DASHBOARD_URL=https://dashboard-mfe-eta.vercel.app
 REACT_APP_TRANSACTIONS_URL=https://transactions-mfe-iota.vercel.app

--- a/shared/vercel.json
+++ b/shared/vercel.json
@@ -6,20 +6,19 @@
   "framework": null,
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "http://44.206.72.128:3034/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "http://44.206.72.128:3035/uploads/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
   ],
   "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests"
-        }
-      ]
-    },
     {
       "source": "/remoteEntry.js",
       "headers": [

--- a/shell/vercel.json
+++ b/shell/vercel.json
@@ -6,20 +6,19 @@
   "framework": null,
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "http://44.206.72.128:3034/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "http://44.206.72.128:3035/uploads/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
   ],
   "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests"
-        }
-      ]
-    },
     {
       "source": "/remoteEntry.js",
       "headers": [

--- a/transactions-mfe/vercel.json
+++ b/transactions-mfe/vercel.json
@@ -6,20 +6,19 @@
   "framework": null,
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "http://44.206.72.128:3034/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "http://44.206.72.128:3035/uploads/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
   ],
   "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests"
-        }
-      ]
-    },
     {
       "source": "/remoteEntry.js",
       "headers": [


### PR DESCRIPTION
- Add proxy rewrites in all vercel.json files for /api/* and /uploads/*
- Update environment variables from absolute URLs to relative paths
- Remove CSP upgrade-insecure-requests header (replaced by proxy solution)
- Update documentation: VERCEL_ENV_VARS.md, VERCEL_ENV_IMPORT.env, hybrid-deployment.md
- Add detailed explanations about proxy functionality and mixed content resolution

The Vercel proxy layer allows HTTPS frontends to communicate with HTTP EC2 backend without browser mixed content errors. Requests to /api/* are proxied to http://44.206.72.128:3034/* and /uploads/* to http://44.206.72.128:3035/uploads/*

BREAKING CHANGE: Environment variables must be updated in Vercel dashboard
- REACT_APP_API_BASE_URL: change from http://44.206.72.128:3034 to /api
- REACT_APP_UPLOAD_URL: change from http://44.206.72.128:3035 to /uploads