### PR TITLE
fix: add force flag to cp command in init-db.sh to prevent restart loop

### DIFF
--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -19,7 +19,7 @@ fi
 
 # SEMPRE sobrescreve o db.json com o template
 echo "📋 Resetando db.json a partir do template..."
-cp "$TEMPLATE_FILE" "$DB_FILE"
+cp -f "$TEMPLATE_FILE" "$DB_FILE"
 
 echo "✅ Banco de dados resetado com sucesso!"
 echo "ℹ️  Base limpa iniciada a partir do template"


### PR DESCRIPTION
The cp command was failing when db.json already existed, causing the container to crash and restart infinitely. Adding -f flag forces overwrite.