### PR TITLE
fix: prevent duplicate path in file download URLs

### DIFF
--- a/shared/src/services/FileUploadService.ts
+++ b/shared/src/services/FileUploadService.ts
@@ -133,6 +133,21 @@ export class FileUploadService {
     if (!filePath) {
       throw new Error('Caminho do arquivo não fornecido');
     }
+
+    // Se filePath já começa com /uploads
+    if (filePath.startsWith('/uploads')) {
+      // Em produção (Vercel), usa URL relativa /uploads (proxy redireciona)
+      // Em local, precisa adicionar a base URL do upload server
+      if (AppConfig.UPLOAD_SERVICE_URL.includes('localhost')) {
+        // Local: remove /api/upload e adiciona a base do upload server
+        const baseUrl = AppConfig.UPLOAD_SERVICE_URL.replace('/api/upload', '');
+        return `${baseUrl}${filePath}`;
+      }
+      // Vercel: usa path relativo (proxy configurado)
+      return filePath;
+    }
+
+    // Fallback para caso legado (não deve acontecer)
     return `${AppConfig.UPLOAD_SERVICE_URL}${filePath}`;
   }
 


### PR DESCRIPTION
FileUploadService.getDownloadUrl was concatenating UPLOAD_SERVICE_URL with filePath, causing /api/upload/uploads/file.jpg instead of /uploads/file.jpg.

Solution:
- Check if filePath starts with /uploads (backend returns complete path)
- Vercel: return filePath directly (/uploads/... proxied to EC2)
- Local: prepend localhost:3035 for direct server access

Before (Vercel): /api/upload + /uploads/file.jpg = /api/upload/uploads/file.jpg (404)
After (Vercel): /uploads/file.jpg (proxied to EC2:3035) ✅
After (Local): http://localhost:3035/uploads/file.jpg ✅

Also adds deploy-backend-ec2.md documentation.